### PR TITLE
feat: 🎸 replace Ti.Platform.osname equality checks with boolean

### DIFF
--- a/tests/__fixtures__/ios sniff - ipad/code.js
+++ b/tests/__fixtures__/ios sniff - ipad/code.js
@@ -1,0 +1,8 @@
+/* global Ti, Titanium */
+if (Ti.Platform.osname === 'iphone' || Ti.Platform.osname === 'ipad') {
+	Ti.API.info('on ios!');
+}
+
+if (Ti.Platform.osname == 'iphone' || Titanium.Platform.osname == 'ipad') { // eslint-disable-line eqeqeq
+	Ti.API.info('on ios!');
+}

--- a/tests/__fixtures__/ios sniff - ipad/output.js
+++ b/tests/__fixtures__/ios sniff - ipad/output.js
@@ -1,0 +1,9 @@
+/* global Ti, Titanium */
+if (true) {
+  Ti.API.info('on ios!');
+}
+
+if (true) {
+  // eslint-disable-line eqeqeq
+  Ti.API.info('on ios!');
+}

--- a/tests/__fixtures__/ios sniff - iphone/code.js
+++ b/tests/__fixtures__/ios sniff - iphone/code.js
@@ -1,0 +1,8 @@
+/* global Ti, Titanium */
+if (Ti.Platform.osname === 'iphone' || Ti.Platform.osname === 'ipad') {
+	Ti.API.info('on ios!');
+}
+
+if ('iphone' == Ti.Platform.osname || 'ipad' === Titanium.Platform.osname) { // eslint-disable-line yoda, eqeqeq
+	Ti.API.info('on ios!');
+}

--- a/tests/__fixtures__/ios sniff - iphone/output.js
+++ b/tests/__fixtures__/ios sniff - iphone/output.js
@@ -1,0 +1,9 @@
+/* global Ti, Titanium */
+if (true) {
+  Ti.API.info('on ios!');
+}
+
+if (true) {
+  // eslint-disable-line yoda, eqeqeq
+  Ti.API.info('on ios!');
+}

--- a/tests/__fixtures__/windows sniff - phone/code.js
+++ b/tests/__fixtures__/windows sniff - phone/code.js
@@ -1,0 +1,8 @@
+/* global Ti, Titanium */
+if (Ti.Platform.osname === 'windowsstore' || Ti.Platform.osname === 'windowsphone') {
+	Ti.API.info('on windows!');
+}
+
+if ('windowsstore' == Ti.Platform.osname || 'windowsphone' === Titanium.Platform.osname) { // eslint-disable-line yoda, eqeqeq
+	Ti.API.info('on windows!');
+}

--- a/tests/__fixtures__/windows sniff - phone/output.js
+++ b/tests/__fixtures__/windows sniff - phone/output.js
@@ -1,0 +1,9 @@
+/* global Ti, Titanium */
+if (true) {
+  Ti.API.info('on windows!');
+}
+
+if (true) {
+  // eslint-disable-line yoda, eqeqeq
+  Ti.API.info('on windows!');
+}

--- a/tests/__fixtures__/windows sniff - store/code.js
+++ b/tests/__fixtures__/windows sniff - store/code.js
@@ -1,0 +1,8 @@
+/* global Ti, Titanium */
+if (Ti.Platform.osname === 'windowsstore' || Ti.Platform.osname === 'windowsphone') {
+	Ti.API.info('on windows!');
+}
+
+if (Ti.Platform.osname == 'windowsstore' || Titanium.Platform.osname == 'windowsphone') { // eslint-disable-line eqeqeq
+	Ti.API.info('on windows!');
+}

--- a/tests/__fixtures__/windows sniff - store/output.js
+++ b/tests/__fixtures__/windows sniff - store/output.js
@@ -1,0 +1,9 @@
+/* global Ti, Titanium */
+if (true) {
+  Ti.API.info('on windows!');
+}
+
+if (true) {
+  // eslint-disable-line eqeqeq
+  Ti.API.info('on windows!');
+}

--- a/tests/plugin_test.js
+++ b/tests/plugin_test.js
@@ -46,12 +46,19 @@ tests['ipad'] = makeTest('ipad', {
 		}
 	}
 });
-tests['windowsstore'] = makeTest('windowsstore', {
-	platform: 'windows',
+tests['simplifies ios Ti.Platform.osname checks when ipad'] = makeTest('ios sniff - ipad', {
+	platform: 'ios',
 	Ti: {
 		Platform: {
-			name: 'windows',
-			osname: 'windowsstore'
+			name: 'iPhone OS'
+		}
+	}
+});
+tests['simplifies ios Ti.Platform.osname checks when iphone'] = makeTest('ios sniff - iphone', {
+	platform: 'ios',
+	Ti: {
+		Platform: {
+			name: 'iOS'
 		}
 	}
 });
@@ -61,6 +68,33 @@ tests['windowsphone'] = makeTest('windowsphone', {
 		Platform: {
 			name: 'windows',
 			osname: 'windowsphone'
+		}
+	}
+});
+tests['windowsstore'] = makeTest('windowsstore', {
+	platform: 'windows',
+	Ti: {
+		Platform: {
+			name: 'windows',
+			osname: 'windowsstore'
+		}
+	}
+});
+tests['simplifies windows Ti.Platform.osname checks when windowsphone'] = makeTest('windows sniff - phone', {
+	platform: 'windows',
+	Ti: {
+		Platform: {
+			name: 'windows',
+			osname: 'windowsphone'
+		}
+	}
+});
+tests['simplifies windows Ti.Platform.osname checks when windowsstore'] = makeTest('windows sniff - store', {
+	platform: 'windows',
+	Ti: {
+		Platform: {
+			name: 'windows',
+			osname: 'windowsstore'
 		}
 	}
 });


### PR DESCRIPTION
sniffs typical Ti.Platform.osname equality checks for 'ipad' or 'iphone;
'windowsstore' or 'windowsphone' and replaces the full logical
expression with a simple true/false